### PR TITLE
Adding support for Laravel and Lumen 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ext-elastic_apm": "*",
         "php": "^7.2",
-        "illuminate/support": "^6.0|^7.0|^8.0"
+        "illuminate/support": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ext-elastic_apm": "*",
         "php": "^7.2",
-        "illuminate/support": "^8.0"
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ext-elastic_apm": "*",
         "php": "^7.2",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -39,9 +39,19 @@ $app->singleton(
 );
 ```
 ```php
-// USE THIS SECTION
+// USE THIS SECTION FOR LARAVEL <= 7
 $app->singleton(Illuminate\Contracts\Debug\ExceptionHandler::class, function ($app) {
     return new Anik\ElasticApm\Exceptions\Handler(new App\Exceptions\Handler($app), [
+        // NotFoundHttpException::class, // (1)
+        // ConnectException::class, // (2)
+    ]);
+});
+```
+
+```php
+// USE THIS SECTION FOR LARAVEL >= 8
+$app->singleton(Illuminate\Contracts\Debug\ExceptionHandler::class, function ($app) {
+    return new Anik\ElasticApm\Exceptions\HandlerThrowable(new App\Exceptions\Handler($app), [
         // NotFoundHttpException::class, // (1)
         // ConnectException::class, // (2)
     ]);
@@ -58,9 +68,19 @@ $app->singleton(
 ```
 
 ```php
-// USE THIS SECTION
+// USE THIS SECTION FOR LUMEN <= 7
 $app->singleton(Illuminate\Contracts\Debug\ExceptionHandler::class, function ($app) {
     return new Anik\ElasticApm\Exceptions\Handler(new App\Exceptions\Handler(), [
+        // NotFoundHttpException::class, // (1)
+        // ConnectException::class, // (2)
+    ]);
+});
+```
+
+```php
+// USE THIS SECTION FOR LUMEN >= 8
+$app->singleton(Illuminate\Contracts\Debug\ExceptionHandler::class, function ($app) {
+    return new Anik\ElasticApm\Exceptions\HandlerThrowable(new App\Exceptions\Handler(), [
         // NotFoundHttpException::class, // (1)
         // ConnectException::class, // (2)
     ]);

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -6,6 +6,7 @@ use Anik\ElasticApm\Spans\ErrorSpan;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 class Handler implements ExceptionHandler
 {
@@ -45,7 +46,7 @@ class Handler implements ExceptionHandler
         return true;
     }
 
-    public function report (Exception $e) {
+    public function report (Throwable $e) {
         // primary handler => (mainly) App\Exceptions\Handler.php will handle Error logging on application log.
         $this->primaryHandler->report($e);
 
@@ -54,11 +55,11 @@ class Handler implements ExceptionHandler
         }
     }
 
-    public function render ($request, Exception $e) {
+    public function render ($request, Throwable $e) {
         return $this->primaryHandler->render($request, $e);
     }
 
-    public function renderForConsole ($output, Exception $e) {
+    public function renderForConsole ($output, Throwable $e) {
         return $this->primaryHandler->renderForConsole($output, $e);
     }
 }

--- a/src/Exceptions/HandlerThrowable.php
+++ b/src/Exceptions/HandlerThrowable.php
@@ -6,8 +6,9 @@ use Anik\ElasticApm\Spans\ErrorSpan;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
-class Handler implements ExceptionHandler
+class HandlerThrowable implements ExceptionHandler
 {
     private $primaryHandler;
     private $ignoredExceptions = [
@@ -45,7 +46,7 @@ class Handler implements ExceptionHandler
         return true;
     }
 
-    public function report (Exception $e) {
+    public function report (Throwable $e) {
         // primary handler => (mainly) App\Exceptions\Handler.php will handle Error logging on application log.
         $this->primaryHandler->report($e);
 
@@ -54,11 +55,11 @@ class Handler implements ExceptionHandler
         }
     }
 
-    public function render ($request, Exception $e) {
+    public function render ($request, Throwable $e) {
         return $this->primaryHandler->render($request, $e);
     }
 
-    public function renderForConsole ($output, Exception $e) {
+    public function renderForConsole ($output, Throwable $e) {
         return $this->primaryHandler->renderForConsole($output, $e);
     }
 }

--- a/src/Exceptions/HandlerThrowable.php
+++ b/src/Exceptions/HandlerThrowable.php
@@ -31,7 +31,7 @@ class HandlerThrowable implements ExceptionHandler
                 'line'      => $trace['line'] ?? 'N/A',
             ];
         });
-        app('apm-agent')->addSpan(new ErrorSpan(new Exception($e->getMessage(), $e->getCode()), $traces));
+        app('apm-agent')->addSpan(new ErrorSpan($e, $traces));
 
         return;
     }

--- a/src/Exceptions/HandlerThrowable.php
+++ b/src/Exceptions/HandlerThrowable.php
@@ -3,9 +3,9 @@
 namespace Anik\ElasticApm\Exceptions;
 
 use Anik\ElasticApm\Spans\ErrorSpan;
-use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Exception;
 use Throwable;
 
 class HandlerThrowable implements ExceptionHandler
@@ -23,7 +23,7 @@ class HandlerThrowable implements ExceptionHandler
         }
     }
 
-    private function logException (Exception $e) {
+    private function logException (Throwable $e) {
         $depth = config('elastic-apm.error.trace_depth', 30);
         $traces = collect($e->getTrace())->take($depth)->map(function ($trace) {
             return [
@@ -31,7 +31,7 @@ class HandlerThrowable implements ExceptionHandler
                 'line'      => $trace['line'] ?? 'N/A',
             ];
         });
-        app('apm-agent')->addSpan(new ErrorSpan($e, $traces));
+        app('apm-agent')->addSpan(new ErrorSpan(new Exception($e->getMessage(), $e->getCode()), $traces));
 
         return;
     }

--- a/src/Spans/ErrorSpan.php
+++ b/src/Spans/ErrorSpan.php
@@ -3,8 +3,8 @@
 namespace Anik\ElasticApm\Spans;
 
 use Anik\ElasticApm\Contracts\SpanContract;
-use Exception;
 use Illuminate\Support\Collection;
+use Throwable;
 
 class ErrorSpan implements SpanContract
 {
@@ -12,7 +12,7 @@ class ErrorSpan implements SpanContract
 
     private $traces, $exception;
 
-    public function __construct (Exception $e, Collection $traces) {
+    public function __construct (Throwable $e, Collection $traces) {
         $this->exception = $e;
         $this->traces = $traces;
     }


### PR DESCRIPTION
Adding a break change!

illuminate/support in version ^8 implements a interface with signature different of the versions <= 7.* adding \Trowable insted of \Exception on report, for example.