### PR TITLE
fixing usage of setLabel

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -102,7 +102,7 @@ class Agent
         $childSpan = $transaction->beginChildSpan($span->getName(), $span->getType(), $span->getSubType());
         if ($labels = $span->getLabels()) {
             foreach ($labels as $key => $value) {
-                $childSpan->setLabel($key, $value);
+                $childSpan->context()->setLabel($key, $value);
             }
         }
         $childSpan->setAction(json_encode($span->getSpanData()));


### PR DESCRIPTION
setLabel has been moved to context() in the latest v1.0.0 beta1. See release notes (breaking changes) https://www.elastic.co/guide/en/apm/agent/php/current/release-notes-v1.0.0-beta1.html

P.s. is this package still under active development or is there a replacement / continuation? I'd love to see this one evolve and am happy to participate in future.